### PR TITLE
fix: normalize website CTAs and QA issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ package-lock.json
 package.json
 scripts/
 setup-skill.sh
+CTA_INVENTORY.md

--- a/Institutions.html
+++ b/Institutions.html
@@ -207,7 +207,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -361,7 +361,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -558,9 +558,9 @@
       <p class="cta-body">Tell us about your product, your timeline, and your regulatory context. We will scope the right security program and respond within 4 business hours.</p>
     </div>
     <div class="cta-btns">
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Private Briefing →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>Run Free AI Scan ↗</a>
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Private Briefing →</a>
+      <a class="btn-cta-primary show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Request Private Briefing →</a>
+      <a class="btn-cta-ghost show-apps" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://calendly.com/koda-credshields/30min" data-book-security>Request Private Briefing →</a>
       <a class="btn-cta-ghost show-chain" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan ↗</a>
     </div>
     <div class="cta-trust">

--- a/about.html
+++ b/about.html
@@ -207,7 +207,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -361,7 +361,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -398,7 +398,7 @@
       <p class="hero-body">We don't just react to hacks — we predict and prevent them. Since 2021, our mission has been clear: secure the future of digital innovation by combining AI intelligence, human expertise, and compliance-driven security frameworks.</p>
       <div class="hero-ctas">
         <a class="btn-primary-lg" href="index.html#security_coverage_360">Explore Our Solutions <span>→</span></a>
-        <a class="btn-secondary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
+        <a class="btn-secondary-lg" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
       </div>
     </div>
     <div class="hero-aside">
@@ -692,10 +692,10 @@
       <p class="cta-body">Get your comprehensive security audit from the team trusted by 200+ protocols and enterprises worldwide. Fast turnaround. Proven track record. Direct access to senior security engineers.</p>
     </div>
     <div class="cta-btns">
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Consultation →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>Run Free AI Scan ↗</a>
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Review ↗</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Consultation →</a>
+      <a class="btn-cta-ghost show-apps" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
+      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Review ↗</a>
     </div>
     <div class="cta-trust">
       <div>

--- a/ai-llm-security.html
+++ b/ai-llm-security.html
@@ -213,7 +213,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -367,7 +367,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -439,7 +439,7 @@
       <h2 class="ai-llm-security-page-title">The new AppSec surface: <em>LLM applications</em>.</h2>
       <p class="ai-llm-security-page-lede">Penetration testing for applications that integrate LLMs, RAG systems, and AI agents. The new attack surface that traditional pentest tools cannot see: prompt injection, indirect injection via RAG, agent abuse, training-data extraction, output guardrail bypass.</p>
       <div class="ai-llm-security-page-cta-row">
-        <button class="ai-llm-security-btn-primary-lg">Book LLM AppSec Engagement</button>
+        <button class="ai-llm-security-btn-primary-lg" data-contact-form>Book LLM AppSec Engagement</button>
         <button class="ai-llm-security-btn-secondary-lg">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Get Sample Report
@@ -703,7 +703,7 @@ When user later queries the knowledge base:
         <div class="ai-llm-security-mini-cta-sub">Talk to a senior engineer. No SDR script, no slide deck. Just a working session about your stack.</div>
       </div>
       <div style="display:flex;gap:10px;flex-wrap:wrap;">
-        <button class="ai-llm-security-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="ai-llm-security-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="ai-llm-security-btn-secondary-lg" data-book-security>Talk to an Engineer</button>
       </div>
     </div>
@@ -721,7 +721,7 @@ When user later queries the knowledge base:
     <h2 class="cta-title">The pentest your auditor will accept.<br>The findings your engineers will fix.</h2>
     <p class="cta-body">Continuous AppSec for SaaS, fintech, and regulated industries. Talk to a senior engineer &mdash; no SDR script, no slide deck, just a working session about your stack.</p>
     <div class="cta-btns">
-      <button class="btn-cta-primary" data-book-security>Book a Pentest</button>
+      <button class="btn-cta-primary" data-contact-form>Book a Pentest</button>
       <button class="btn-cta-ghost" data-book-security>Talk to an Engineer</button>
     </div>
     <div class="cta-trust">

--- a/ai-security-tools.html
+++ b/ai-security-tools.html
@@ -207,7 +207,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -361,7 +361,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -397,7 +397,7 @@
       <p class="hero-body">SolidityScan, our proprietary AI-powered tool, instantly detects critical vulnerabilities in smart contracts, empowering developers to ship safer code without waiting for full audits.</p>
       <div class="hero-ctas">
         <a class="btn-primary-lg" href="https://youtube.com/playlist?list=PLvUdBj6B_rh0qDFaH90mCgUkEZ1lXdMmB&si=0Ne75ggLa49ZjlRBen">View Demo <span>→</span></a>
-        <a class="btn-secondary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
+        <a class="btn-secondary-lg" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
       </div>
     </div>
     <div class="hero-aside">
@@ -416,7 +416,7 @@
           <span class="dossier-kv-label">Output</span>
           <span class="dossier-kv-value ok">Dev-ready fixes</span>
         </div>
-        <div class="dossier-card-foot"><span>Free quickscan: <strong>No signup</strong></span><a class="dossier-card-cta" href="./index.html#quickscan_container_sec">Run scan →</a></div>
+        <div class="dossier-card-foot"><span>Free quickscan: <strong>No signup</strong></span><a class="dossier-card-cta" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run scan →</a></div>
       </div>
     </div>
   </div>
@@ -629,10 +629,10 @@
     <div class="cta-btns">
       <!-- APPS buttons -->
       <a class="btn-cta-primary show-apps" href="#" onclick="window.open(' https://youtube.com/playlist?list=PLvUdBj6B_rh0qDFaH90mCgUkEZ1lXdMmB&si=0Ne75ggLa49ZjlRB', '_blank');return false;">View Demo</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Schedule Consultation</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Schedule Consultation</a>
       <!-- CHAIN buttons -->
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Review ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
+      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Review ↗</a>
     </div>
     <!-- Shared trust strip -->
     <div class="cta-trust">

--- a/api-security.html
+++ b/api-security.html
@@ -202,7 +202,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -356,7 +356,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -464,7 +464,7 @@
       <h2 class="api-security-page-title">Where modern <em>breaches happen</em>.</h2>
       <p class="api-security-page-lede">REST, GraphQL, and gRPC pentesting against OWASP API Security Top 10 (2023). Auth bypasses, BOLA at scale, GraphQL introspection abuse — the vulnerabilities scanners can't even enumerate.</p>
       <div class="api-security-page-cta-row">
-        <button class="api-security-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="api-security-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="api-security-btn-secondary-lg">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Get Sample Report
@@ -818,7 +818,7 @@
         <div class="api-security-mini-cta-sub">Talk to a senior engineer. No SDR script, no slide deck — just a working session about your stack.</div>
       </div>
       <div style="display:flex;gap:10px;flex-wrap:wrap;">
-        <button class="api-security-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="api-security-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="api-security-btn-secondary-lg" data-book-security>Talk to an Engineer</button>
       </div>
     </div>
@@ -924,7 +924,7 @@
     <h2 class="api-security-cta-title">The pentest your auditor will accept.<br>The findings your engineers will fix.</h2>
     <p class="api-security-cta-body">Continuous AppSec for SaaS, fintech, and regulated industries. Talk to a senior engineer &mdash; no SDR script, no slide deck, just a working session about your stack.</p>
     <div class="api-security-cta-btns">
-      <button class="api-security-btn-cta-primary" data-book-security>Book a Pentest</button>
+      <button class="api-security-btn-cta-primary" data-contact-form>Book a Pentest</button>
       <button class="api-security-btn-cta-ghost" data-book-security>Talk to an Engineer</button>
     </div>
     <div class="api-security-cta-trust">

--- a/appsec-maturity.html
+++ b/appsec-maturity.html
@@ -213,7 +213,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -367,7 +367,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -691,7 +691,7 @@ Culture          L2    L1
         <div class="appsec-maturity-mini-cta-sub">Talk to a senior engineer. No SDR script, no slide deck. Just a working session about your stack.</div>
       </div>
       <div style="display:flex;gap:10px;flex-wrap:wrap;">
-        <button class="appsec-maturity-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="appsec-maturity-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="appsec-maturity-btn-secondary-lg" data-book-security>Talk to an Engineer</button>
       </div>
     </div>
@@ -709,7 +709,7 @@ Culture          L2    L1
     <h2 class="cta-title">The pentest your auditor will accept.<br>The findings your engineers will fix.</h2>
     <p class="cta-body">Continuous AppSec for SaaS, fintech, and regulated industries. Talk to a senior engineer &mdash; no SDR script, no slide deck, just a working session about your stack.</p>
     <div class="cta-btns">
-      <button class="btn-cta-primary" data-book-security>Book a Pentest</button>
+      <button class="btn-cta-primary" data-contact-form>Book a Pentest</button>
       <button class="btn-cta-ghost" data-book-security>Talk to an Engineer</button>
     </div>
     <div class="cta-trust">

--- a/blockchain-security.html
+++ b/blockchain-security.html
@@ -204,7 +204,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -358,7 +358,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -394,7 +394,7 @@
       <h1 class="hero-headline">Blockchain security audits<br>&amp; <em>testing</em>.</h1>
       <p class="hero-body">CredShields has extensive experience researching the security of public blockchains such as Bitcoin, Ethereum, Cosmos, and others — with deep expertise across P2P communication, node security, RPC calls, cryptography, consensus mechanisms, and asset transactions.</p>
       <div class="hero-ctas">
-        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Schedule a Meeting <span>→</span></a>
+        <a class="btn-primary-lg" href="https://calendly.com/koda-credshields/30min" data-book-security>Schedule a Meeting <span>→</span></a>
         <a class="btn-secondary-lg" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
       </div>
     </div>
@@ -414,7 +414,7 @@
           <span class="dossier-kv-label">Retests</span>
           <span class="dossier-kv-value ok">Free · 90 days</span>
         </div>
-        <div class="dossier-card-foot"><span>Pre-launch slots open</span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Claim slot →</a></div>
+        <div class="dossier-card-foot"><span>Pre-launch slots open</span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Claim slot →</a></div>
       </div>
     </div>
   </div>
@@ -650,10 +650,10 @@
       <p class="cta-body">Don't let security vulnerabilities threaten your blockchain infrastructure. Get a comprehensive audit from the team trusted by leading blockchain projects.</p>
     </div>
     <div class="cta-btns">
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start a Pentest →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Talk to an Expert ↗</a>
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Schedule a Meeting →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Schedule Consultation ↗</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start a Pentest →</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Talk to an Expert ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://calendly.com/koda-credshields/30min" data-book-security>Schedule a Meeting →</a>
+      <a class="btn-cta-ghost show-chain" href="https://calendly.com/koda-credshields/30min" data-book-security>Schedule Consultation ↗</a>
     </div>
     <div class="cta-trust">
       <div>

--- a/brand-guidelines.html
+++ b/brand-guidelines.html
@@ -205,7 +205,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -359,7 +359,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -395,7 +395,7 @@
       <p class="hero-body">Use CredShields assets and guidelines to confidently promote your security services across all communication channels.</p>
       <div class="hero-ctas">
         <a class="btn-primary-lg" href="index.html#security_coverage_360">Explore Solutions <span>→</span></a>
-        <a class="btn-secondary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
+        <a class="btn-secondary-lg" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
       </div>
     </div>
     <div class="hero-aside">
@@ -620,11 +620,11 @@
     </div>
     <div class="cta-btns">
       <!-- APPS buttons -->
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Consultation →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>Run Free AI Scan ↗</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Consultation →</a>
+      <a class="btn-cta-ghost show-apps" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan ↗</a>
       <!-- CHAIN buttons -->
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Review ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
+      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Review ↗</a>
     </div>
     <!-- Trust strip -->
     <div class="cta-trust">

--- a/careers.html
+++ b/careers.html
@@ -205,7 +205,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -359,7 +359,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -400,7 +400,7 @@
       <p class="hero-body">Great security work doesn't happen by accident. It takes sharp people, deep expertise, and a genuine obsession with getting it right. Sound like you? Keep scrolling.</p>
       <div class="hero-ctas">
         <a class="btn-primary-lg" href="index.html#security_coverage_360">Explore Solutions <span>→</span></a>
-        <a class="btn-secondary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
+        <a class="btn-secondary-lg" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
       </div>
     </div>
     <div class="hero-aside">

--- a/cloud-pentest.html
+++ b/cloud-pentest.html
@@ -202,7 +202,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -356,7 +356,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -464,7 +464,7 @@
       <h2 class="cloud-security-page-title">Your cloud isn't a <em>misconfiguration audit</em>.</h2>
       <p class="cloud-security-page-lede">AWS, GCP, and Azure security reviews focused on actual attack paths — not CIS benchmark checklists. We map IAM privilege chains, lateral movement opportunities, and the seams between services.</p>
       <div class="cloud-security-page-cta-row">
-        <button class="cloud-security-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="cloud-security-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="cloud-security-btn-secondary-lg">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Get Sample Report
@@ -751,7 +751,7 @@ ec2-readonly-role
         <div class="cloud-security-mini-cta-sub">Talk to a senior engineer. No SDR script, no slide deck — just a working session about your stack.</div>
       </div>
       <div style="display:flex;gap:10px;flex-wrap:wrap;">
-        <button class="cloud-security-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="cloud-security-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="cloud-security-btn-secondary-lg" data-book-security>Talk to an Engineer</button>
       </div>
     </div>
@@ -857,7 +857,7 @@ ec2-readonly-role
     <h2 class="cloud-security-cta-title">The pentest your auditor will accept.<br>The findings your engineers will fix.</h2>
     <p class="cloud-security-cta-body">Continuous AppSec for SaaS, fintech, and regulated industries. Talk to a senior engineer &mdash; no SDR script, no slide deck, just a working session about your stack.</p>
     <div class="cloud-security-cta-btns">
-      <button class="cloud-security-btn-cta-primary" data-book-security>Book a Pentest</button>
+      <button class="cloud-security-btn-cta-primary" data-contact-form>Book a Pentest</button>
       <button class="cloud-security-btn-cta-ghost" data-book-security>Talk to an Engineer</button>
     </div>
     <div class="cloud-security-cta-trust">

--- a/cloud-security.html
+++ b/cloud-security.html
@@ -207,7 +207,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -361,7 +361,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -397,7 +397,7 @@
       <h1 class="hero-headline">Secure the cloud that runs your <em>business</em>.</h1>
       <p class="hero-body">Cloud misconfigurations are the #1 cause of enterprise breaches. CredShields audits AWS, Azure, and GCP to detect vulnerabilities and ensure compliance.</p>
       <div class="hero-ctas">
-        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Cloud Security Audit <span>→</span></a>
+        <a class="btn-primary-lg" href="https://calendly.com/koda-credshields/30min" data-book-security>Cloud Security Audit <span>→</span></a>
         <a class="btn-secondary-lg" href="#process">See our process <span>↗</span></a>
       </div>
     </div>
@@ -419,7 +419,7 @@
           <span class="dossier-kv-label">Retests</span>
           <span class="dossier-kv-value ok">Free · 90 days</span>
         </div>
-        <div class="dossier-card-foot"><span>Next available: <strong>Mon 05 May</strong></span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Claim slot →</a></div>
+        <div class="dossier-card-foot"><span>Next available: <strong>Mon 05 May</strong></span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Claim slot →</a></div>
       </div>
     </div>
   </div>
@@ -654,11 +654,11 @@
     </div>
     <div class="cta-btns">
       <!-- APPS buttons -->
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Cloud Security Audit →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Schedule Consultation ↗</a>
+      <a class="btn-cta-primary show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Cloud Security Audit →</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Schedule Consultation ↗</a>
       <!-- CHAIN buttons -->
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Review ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
+      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Review ↗</a>
     </div>
     <div class="cta-trust">
       <div>

--- a/compliance.html
+++ b/compliance.html
@@ -202,7 +202,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -356,7 +356,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -472,7 +472,7 @@
       <h2 class="compliance-page-title">Pentest evidence your <em>auditor will accept</em>.</h2>
       <p class="compliance-page-lede">SOC 2 Type II, ISO 27001, PCI DSS Level 1, HIPAA, GDPR — pentest scoping, execution, and evidence packages designed to drop straight into your audit binder.</p>
       <div class="compliance-page-cta-row">
-        <button class="compliance-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="compliance-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="compliance-btn-secondary-lg">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Get Sample Report
@@ -825,7 +825,7 @@
         <div class="compliance-mini-cta-sub">Talk to a senior engineer. No SDR script, no slide deck — just a working session about your stack.</div>
       </div>
       <div style="display:flex;gap:10px;flex-wrap:wrap;">
-        <button class="compliance-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="compliance-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="compliance-btn-secondary-lg" data-book-security>Talk to an Engineer</button>
       </div>
     </div>
@@ -931,7 +931,7 @@
     <h2 class="compliance-cta-title">The pentest your auditor will accept.<br>The findings your engineers will fix.</h2>
     <p class="compliance-cta-body">Continuous AppSec for SaaS, fintech, and regulated industries. Talk to a senior engineer &mdash; no SDR script, no slide deck, just a working session about your stack.</p>
     <div class="compliance-cta-btns">
-      <button class="compliance-btn-cta-primary" data-book-security>Book a Pentest</button>
+      <button class="compliance-btn-cta-primary" data-contact-form>Book a Pentest</button>
       <button class="compliance-btn-cta-ghost" data-book-security>Talk to an Engineer</button>
     </div>
     <div class="compliance-cta-trust">

--- a/continuous-appsec.html
+++ b/continuous-appsec.html
@@ -202,7 +202,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -356,7 +356,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -456,7 +456,7 @@
       <h2 class="continuous-appsec-page-title">AppSec that <em>runs with your team</em>.</h2>
       <p class="continuous-appsec-page-lede">Continuous pentesting integrated with your CI, your Jira, and your Slack. Every meaningful release tested by senior engineers. Findings landed where your team already works — not in a quarterly PDF.</p>
       <div class="continuous-appsec-page-cta-row">
-        <button class="continuous-appsec-btn-primary-lg">Start Continuous AppSec</button>
+        <button class="continuous-appsec-btn-primary-lg" data-contact-form>Start Continuous AppSec</button>
         <button class="continuous-appsec-btn-secondary-lg">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Get Sample Report
@@ -889,7 +889,7 @@
         <div class="continuous-appsec-mini-cta-sub">Talk to a senior engineer. No SDR script, no slide deck — just a working session about your stack.</div>
       </div>
       <div style="display:flex;gap:10px;flex-wrap:wrap;">
-        <button class="continuous-appsec-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="continuous-appsec-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="continuous-appsec-btn-secondary-lg" data-book-security>Talk to an Engineer</button>
       </div>
     </div>
@@ -1062,7 +1062,7 @@
     <h2 class="continuous-appsec-cta-title">The pentest your auditor will accept.<br>The findings your engineers will fix.</h2>
     <p class="continuous-appsec-cta-body">Continuous AppSec for SaaS, fintech, and regulated industries. Talk to a senior engineer &mdash; no SDR script, no slide deck, just a working session about your stack.</p>
     <div class="continuous-appsec-cta-btns">
-      <button class="continuous-appsec-btn-cta-primary" data-book-security>Book a Pentest</button>
+      <button class="continuous-appsec-btn-cta-primary" data-contact-form>Book a Pentest</button>
       <button class="continuous-appsec-btn-cta-ghost" data-book-security>Talk to an Engineer</button>
     </div>
     <div class="continuous-appsec-cta-trust">

--- a/continuous-monitoring.html
+++ b/continuous-monitoring.html
@@ -205,7 +205,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -359,7 +359,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -606,9 +606,9 @@
       <p class="cta-body">Don't let security vulnerabilities threaten your protocol and users. Get a comprehensive audit from the team trusted by the world's leading DeFi protocols.</p>
     </div>
     <div class="cta-btns">
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start a Pentest →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Talk to an Expert ↗</a>
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Consultation →</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start a Pentest →</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Talk to an Expert ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Consultation →</a>
       <a class="btn-cta-ghost show-chain" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan ↗</a>
     </div>
     <div class="cta-trust">

--- a/crosschainbridge.html
+++ b/crosschainbridge.html
@@ -196,7 +196,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -350,7 +350,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -385,7 +385,7 @@
       <h1 class="hero-headline">$2 Billion Lost to Bridge Hacks. Yours <em>cannot</em> be next.</h1>
       <p class="hero-body">Cross-chain bridges are the single most exploited category in all of Web3 — responsible for over $3B in losses in the last year alone. Any institutional product moving assets between chains depends on bridge security that has historically been catastrophically inadequate.</p>
       <div class="hero-ctas">
-        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Security Briefing <span>→</span></a>
+        <a class="btn-primary-lg" href="https://calendly.com/koda-credshields/30min" data-book-security>Request Security Briefing <span>→</span></a>
         <a class="btn-secondary-lg" href="#attack_surface">View Risk Surface <span>↗</span></a>
       </div>
     </div>
@@ -405,7 +405,7 @@
           <span class="dossier-kv-label">Retainer</span>
           <span class="dossier-kv-value ok">Real-time monitoring</span>
         </div>
-        <div class="dossier-card-foot"><span>Engagement: <strong>By briefing</strong></span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Brief us →</a></div>
+        <div class="dossier-card-foot"><span>Engagement: <strong>By briefing</strong></span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Brief us →</a></div>
       </div>
     </div>
   </div>
@@ -550,9 +550,9 @@
       <p class="cta-body">Request a bridge security briefing. We will scope the right audit across your bridge smart contracts, validator infrastructure, and economic security model.</p>
     </div>
     <div class="cta-btns">
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start a Pentest →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Talk to an Expert ↗</a>
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Security Briefing →</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start a Pentest →</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Talk to an Expert ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://calendly.com/koda-credshields/30min" data-book-security>Request Security Briefing →</a>
       <a class="btn-cta-ghost show-chain" href="https://solidityscan.com/quickscan" data-free-ai-scan>
         <span style="color:#ffffff;font-weight:700;margin-right:1px">Run Free</span>
         <img src="images/ai_icon_magic.svg" alt="ai_icon_magic" style="width:16px;height:16px;vertical-align:middle;" />

--- a/dapp-protocol-security.html
+++ b/dapp-protocol-security.html
@@ -205,7 +205,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -359,7 +359,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -395,7 +395,7 @@
       <h1 class="hero-headline">Full-stack security for dApps &amp; <em>protocols</em>.</h1>
       <p class="hero-body">Smart contracts are just one layer. dApps and full protocols rely on off-chain integrations, APIs, governance, and oracles that are equally vulnerable to attack.</p>
       <div class="hero-ctas">
-        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Schedule a Meeting <span>→</span></a>
+        <a class="btn-primary-lg" href="https://calendly.com/koda-credshields/30min" data-book-security>Schedule a Meeting <span>→</span></a>
         <a class="btn-secondary-lg" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
       </div>
     </div>
@@ -415,7 +415,7 @@
           <span class="dossier-kv-label">Retests</span>
           <span class="dossier-kv-value ok">Free · 90 days</span>
         </div>
-        <div class="dossier-card-foot"><span>Next available: <strong>Mon 05 May</strong></span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Claim slot →</a></div>
+        <div class="dossier-card-foot"><span>Next available: <strong>Mon 05 May</strong></span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Claim slot →</a></div>
       </div>
     </div>
   </div>
@@ -654,9 +654,9 @@
       <p class="cta-body">Don't let security vulnerabilities threaten your protocol and users. Get a comprehensive audit from the team trusted by the world's leading DeFi protocols.</p>
     </div>
     <div class="cta-btns">
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start a Pentest →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Talk to an Expert ↗</a>
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Consultation →</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start a Pentest →</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Talk to an Expert ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Consultation →</a>
       <a class="btn-cta-ghost show-chain" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan ↗</a>
     </div>
     <div class="cta-trust">

--- a/devsecops.html
+++ b/devsecops.html
@@ -213,7 +213,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -367,7 +367,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -439,7 +439,7 @@
       <h2 class="devsecops-page-title">Embedded AppSec, <em>without the overhead</em>.</h2>
       <p class="devsecops-page-lede">Technical deep-dive into how CredShields integrates with GitHub, GitLab, Bitbucket, Jira, Linear, Slack, and your existing tool stack. Real YAML, real OIDC trust, real merge-gate behavior. The how-it-works companion to Continuous AppSec.</p>
       <div class="devsecops-page-cta-row">
-        <button class="devsecops-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="devsecops-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="devsecops-btn-secondary-lg">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Get Sample Report
@@ -703,7 +703,7 @@
         <div class="devsecops-mini-cta-sub">Talk to a senior engineer. No SDR script, no slide deck. Just a working session about your stack.</div>
       </div>
       <div style="display:flex;gap:10px;flex-wrap:wrap;">
-        <button class="devsecops-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="devsecops-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="devsecops-btn-secondary-lg" data-book-security>Talk to an Engineer</button>
       </div>
     </div>
@@ -721,7 +721,7 @@
     <h2 class="cta-title">The pentest your auditor will accept.<br>The findings your engineers will fix.</h2>
     <p class="cta-body">Continuous AppSec for SaaS, fintech, and regulated industries. Talk to a senior engineer &mdash; no SDR script, no slide deck, just a working session about your stack.</p>
     <div class="cta-btns">
-      <button class="btn-cta-primary" data-book-security>Book a Pentest</button>
+      <button class="btn-cta-primary" data-contact-form>Book a Pentest</button>
       <button class="btn-cta-ghost" data-book-security>Talk to an Engineer</button>
     </div>
     <div class="cta-trust">

--- a/ecosystem.html
+++ b/ecosystem.html
@@ -205,7 +205,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -359,7 +359,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -609,10 +609,10 @@
       <p class="cta-body">Don't wait for a security incident to happen. Get your comprehensive security audit from the team trusted by leading fortune 500 companies.</p>
     </div>
     <div class="cta-btns">
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start a Pentest →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Talk to an Expert ↗</a>
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Review ↗</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start a Pentest →</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Talk to an Expert ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
+      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Review ↗</a>
     </div>
     <div class="cta-trust">
       <div>

--- a/enterprise-security.html
+++ b/enterprise-security.html
@@ -207,7 +207,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -361,7 +361,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -397,7 +397,7 @@
       <h1 class="hero-headline">Enterprise-grade protection for apps &amp; <em>infrastructure</em>.</h1>
       <p class="hero-body">From SaaS platforms to banks and fintechs, enterprises face evolving cyber threats and compliance obligations. CredShields delivers penetration testing, mobile app security reviews, and web application audits aligned with global standards.</p>
       <div class="hero-ctas">
-        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book a Consultation <span>→</span></a>
+        <a class="btn-primary-lg" href="https://calendly.com/koda-credshields/30min" data-book-security>Book a Consultation <span>→</span></a>
         <a class="btn-secondary-lg" href="#approach">See our approach <span>↗</span></a>
       </div>
     </div>
@@ -417,7 +417,7 @@
           <span class="dossier-kv-label">Retests</span>
           <span class="dossier-kv-value ok">Free · 90 days</span>
         </div>
-        <div class="dossier-card-foot"><span>Next available: <strong>Mon 05 May</strong></span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Claim slot →</a></div>
+        <div class="dossier-card-foot"><span>Next available: <strong>Mon 05 May</strong></span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Claim slot →</a></div>
       </div>
     </div>
   </div>
@@ -649,11 +649,11 @@
     </div>
     <div class="cta-btns">
       <!-- APPS buttons -->
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start Enterprise Audit →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Schedule Consultation ↗</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start Enterprise Audit →</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Schedule Consultation ↗</a>
       <!-- CHAIN buttons -->
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Review ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
+      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Review ↗</a>
     </div>
     <!-- Trust strip -->
     <div class="cta-trust">

--- a/fintech-security.html
+++ b/fintech-security.html
@@ -207,7 +207,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -361,7 +361,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -397,8 +397,8 @@
       <h1 class="hero-headline">Safeguarding trust in finance &amp; <em>fintech</em>.</h1>
       <p class="hero-body">Modern SaaS and digital-first enterprises operate in multi-cloud environments, with complex infrastructures and millions of users. CredShields provides penetration testing, cloud security reviews, and compliance-focused audits.</p>
       <div class="hero-ctas">
-        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Audit <span>→</span></a>
-        <a class="btn-secondary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
+        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Audit <span>→</span></a>
+        <a class="btn-secondary-lg" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
       </div>
     </div>
     <div class="hero-aside">
@@ -417,7 +417,7 @@
           <span class="dossier-kv-label">Retests</span>
           <span class="dossier-kv-value ok">Free · 90 days</span>
         </div>
-        <div class="dossier-card-foot"><span>Auditor-ready reports</span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Claim slot →</a></div>
+        <div class="dossier-card-foot"><span>Auditor-ready reports</span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Claim slot →</a></div>
       </div>
     </div>
   </div>
@@ -629,11 +629,11 @@
     </div>
     <div class="cta-btns">
       <!-- APPS buttons -->
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start Audit</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Schedule Consultation</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start Audit</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Schedule Consultation</a>
       <!-- CHAIN buttons -->
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Review ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
+      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Review ↗</a>
     </div>
     <!-- Shared trust strip -->
     <div class="cta-trust">

--- a/gaming-security.html
+++ b/gaming-security.html
@@ -205,7 +205,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -359,7 +359,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -394,8 +394,8 @@
       <h1 class="hero-headline">Protecting the future of digital <em>assets</em> &amp; entertainment</h1>
       <p class="hero-body">The gaming and NFT sectors handle millions of daily transactions, making them prime targets for fraud and exploits. CredShields delivers end-to-end security for blockchain games, NFT marketplaces, and metaverse platforms.</p>
       <div class="hero-ctas">
-        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Secure Your Game <span>→</span></a>
-        <a class="btn-secondary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
+        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Secure Your Game <span>→</span></a>
+        <a class="btn-secondary-lg" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
       </div>
     </div>
     <div class="hero-aside">
@@ -416,7 +416,7 @@
           <span class="dossier-kv-label">Outcome</span>
           <span class="dossier-kv-value ok">Fraud-proof launch</span>
         </div>
-        <div class="dossier-card-foot"><span>Next available: <strong>Mon 5 May</strong></span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Claim slot →</a></div>
+        <div class="dossier-card-foot"><span>Next available: <strong>Mon 5 May</strong></span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Claim slot →</a></div>
       </div>
     </div>
   </div>
@@ -609,11 +609,11 @@
     </div>
     <div class="cta-btns">
       <!-- APPS buttons -->
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Secure My Game →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Schedule Consultation ↗</a>
+      <a class="btn-cta-primary show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Secure My Game →</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Schedule Consultation ↗</a>
       <!-- CHAIN buttons -->
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Review ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
+      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Review ↗</a>
     </div>
     <!-- Trust strip -->
     <div class="cta-trust">

--- a/healthcare-security.html
+++ b/healthcare-security.html
@@ -213,7 +213,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -367,7 +367,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -447,7 +447,7 @@
       <h2 class="healthcare-security-page-title">Pentest evidence that <em>survives an OCR investigation</em>.</h2>
       <p class="healthcare-security-page-lede">CredShields delivers HIPAA-aligned penetration testing for digital health platforms, EHR vendors, telehealth, healthtech SaaS, clinical research platforms, and life sciences manufacturers. HIPAA Security Rule, HITRUST CSF, FDA cybersecurity guidance, and state-by-state breach notification framing built into every report.</p>
       <div class="healthcare-security-page-cta-row">
-        <button class="healthcare-security-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="healthcare-security-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="healthcare-security-btn-secondary-lg">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Get Sample Report
@@ -724,7 +724,7 @@
         <div class="healthcare-security-mini-cta-sub">Talk to a senior engineer who has worked with companies in your industry. No SDR script, no slide deck. Just a working session about your stack and your compliance posture.</div>
       </div>
       <div style="display:flex;gap:10px;flex-wrap:wrap;">
-        <button class="healthcare-security-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="healthcare-security-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="healthcare-security-btn-secondary-lg" data-book-security>Talk to an Engineer</button>
       </div>
     </div>
@@ -742,7 +742,7 @@
     <h2 class="cta-title">The pentest your auditor will accept.<br>The findings your engineers will fix.</h2>
     <p class="cta-body">Continuous AppSec for SaaS, fintech, and regulated industries. Talk to a senior engineer &mdash; no SDR script, no slide deck, just a working session about your stack.</p>
     <div class="cta-btns">
-      <button class="btn-cta-primary" data-book-security>Book a Pentest</button>
+      <button class="btn-cta-primary" data-contact-form>Book a Pentest</button>
       <button class="btn-cta-ghost" data-book-security>Talk to an Engineer</button>
     </div>
     <div class="cta-trust">

--- a/incident-response.html
+++ b/incident-response.html
@@ -207,7 +207,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -361,7 +361,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -397,7 +397,7 @@
       <p class="hero-body">Our team combines blockchain forensics, cyber forensics, exploit analysis, and security engineering to guide your organization through the highest-stakes moments.</p>
       <div class="hero-ctas">
         <a class="btn-primary-lg" href="index.html#security_coverage_360">Explore our solutions <span>→</span></a>
-        <a class="btn-secondary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>Run free AI scan <span>↗</span></a>
+        <a class="btn-secondary-lg" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run free AI scan <span>↗</span></a>
       </div>
     </div>
     <div class="hero-aside">
@@ -416,7 +416,7 @@
           <span class="dossier-kv-label">Post-mortem</span>
           <span class="dossier-kv-value ok">Audit-grade</span>
         </div>
-        <div class="dossier-card-foot"><span>Hotline available <strong>24/7</strong></span><a class="dossier-card-cta" href="./index.html#quickscan_container_sec">Engage now →</a></div>
+        <div class="dossier-card-foot"><span>Hotline available <strong>24/7</strong></span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Engage now →</a></div>
       </div>
     </div>
   </div>
@@ -555,15 +555,15 @@
     </div>
     <div class="cta-btns">
       <!-- APPS buttons -->
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Consultation</a>
-      <a class="btn-cta-ghost show-apps" style="cursor:pointer;display:inline-flex;align-items:center;gap:6px;" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Consultation</a>
+      <a class="btn-cta-ghost show-apps" style="cursor:pointer;display:inline-flex;align-items:center;gap:6px;" href="https://solidityscan.com/quickscan" data-free-ai-scan>
         <span style="color: #ffffff; font-weight: 700; margin-right: 1px">Run Free</span>
         <img src="images/ai_icon_magic.svg" alt="ai_icon_magic" style="width:18px;height:18px;object-fit:contain;" />
         <span style="color: #38ff7e; font-weight: 700; margin-left: 1px">AI Scan</span>
       </a>
       <!-- CHAIN buttons -->
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Review ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
+      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Review ↗</a>
     </div>
     <!-- Shared trust strip -->
     <div class="cta-trust">

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -367,7 +367,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -421,13 +421,13 @@
 
     <!-- APPS CTAs -->
     <div class="hero-ctas show-apps-flex">
-      <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start a Pentest <span>→</span></a>
-      <a class="btn-secondary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Talk to an Expert <span>↗</span></a>
+      <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start a Pentest <span>→</span></a>
+      <a class="btn-secondary-lg" href="https://calendly.com/koda-credshields/30min" data-book-security>Talk to an Expert <span>↗</span></a>
     </div>
     <!-- CHAIN CTAs -->
     <div class="hero-ctas show-chain-flex">
-      <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Audit <span>→</span></a>
-      <a class="btn-secondary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
+      <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Audit <span>→</span></a>
+      <a class="btn-secondary-lg" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
     </div>
 
    </div><!-- /.hero-content -->
@@ -454,7 +454,7 @@
       </div>
       <div class="dossier-card-foot">
         <span>Next available: <strong>Mon 28 Apr</strong></span>
-        <a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Claim slot →</a>
+        <a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Claim slot →</a>
       </div>
     </div>
 
@@ -479,7 +479,7 @@
       </div>
       <div class="dossier-card-foot">
         <span>Next slot: <strong>Mon 28 Apr</strong></span>
-        <a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book audit →</a>
+        <a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Book audit →</a>
       </div>
     </div>
    </div><!-- /.hero-aside -->
@@ -576,7 +576,7 @@
       Continuous AppSec for SaaS, fintech, and regulated industries. Audit-ready, integrated where your team already works.
     </p>
     <div class="app_home-hero-ctas">
-      <button class="app_home-btn-primary-lg" data-book-security>Start a Pentest</button>
+      <button class="app_home-btn-primary-lg" data-contact-form>Start a Pentest</button>
       <button class="app_home-btn-secondary-lg">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
         Get Sample Report
@@ -623,7 +623,7 @@
       </div>
       <div class="dossier-card-foot">
         <span>Next available: <strong>Mon 5 May</strong></span>
-        <a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Claim slot →</a>
+        <a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Claim slot →</a>
       </div>
     </div>
    </div><!-- /.app_home-hero-aside -->
@@ -1384,11 +1384,11 @@
     </div>
     <div class="cta-btns">
       <!-- APPS buttons -->
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start a Pentest →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Talk to an Expert ↗</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start a Pentest →</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Talk to an Expert ↗</a>
       <!-- CHAIN buttons -->
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Review ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
+      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Review ↗</a>
     </div>
     <!-- Shared trust strip -->
     <div class="cta-trust">

--- a/industry-ecommerce.html
+++ b/industry-ecommerce.html
@@ -213,7 +213,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -367,7 +367,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -447,7 +447,7 @@
       <h2 class="industry-ecommerce-page-title">Pentest evidence for <em>card data and revenue flows</em>.</h2>
       <p class="industry-ecommerce-page-lede">CredShields delivers PCI DSS-aligned penetration testing for e-commerce platforms, marketplaces, omnichannel retail, and direct-to-consumer brands. Magecart-class supply chain attacks, coupon stacking and revenue exploitation, ATO via account-recovery flaws, fraud system bypass. PCI 11.3 evidence on every engagement.</p>
       <div class="industry-ecommerce-page-cta-row">
-        <button class="industry-ecommerce-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="industry-ecommerce-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="industry-ecommerce-btn-secondary-lg">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Get Sample Report
@@ -719,7 +719,7 @@
         <div class="industry-ecommerce-mini-cta-sub">Talk to a senior engineer who has worked with companies in your industry. No SDR script, no slide deck. Just a working session about your stack and your compliance posture.</div>
       </div>
       <div style="display:flex;gap:10px;flex-wrap:wrap;">
-        <button class="industry-ecommerce-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="industry-ecommerce-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="industry-ecommerce-btn-secondary-lg" data-book-security>Talk to an Engineer</button>
       </div>
     </div>
@@ -737,7 +737,7 @@
     <h2 class="cta-title">The pentest your auditor will accept.<br>The findings your engineers will fix.</h2>
     <p class="cta-body">Continuous AppSec for SaaS, fintech, and regulated industries. Talk to a senior engineer &mdash; no SDR script, no slide deck, just a working session about your stack.</p>
     <div class="cta-btns">
-      <button class="btn-cta-primary" data-book-security>Book a Pentest</button>
+      <button class="btn-cta-primary" data-contact-form>Book a Pentest</button>
       <button class="btn-cta-ghost" data-book-security>Talk to an Engineer</button>
     </div>
     <div class="cta-trust">

--- a/industry-edtech.html
+++ b/industry-edtech.html
@@ -213,7 +213,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -367,7 +367,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -447,7 +447,7 @@
       <h2 class="industry-edtech-page-title">EdTech AppSec for the <em>FERPA / COPPA / state-law overlay</em>.</h2>
       <p class="industry-edtech-page-lede">CredShields delivers pentest evidence for EdTech platforms serving K-12, higher education, and workforce learning. FERPA-aligned testing, COPPA-aware data flow review, state student-privacy-law mapping (SOPPA, ESSA, CSPC, NYEd Law 2-d), and the SSO and rostering integration coverage that K-12 IT and higher ed CIOs ask about.</p>
       <div class="industry-edtech-page-cta-row">
-        <button class="industry-edtech-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="industry-edtech-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="industry-edtech-btn-secondary-lg">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Get Sample Report
@@ -724,7 +724,7 @@
         <div class="industry-edtech-mini-cta-sub">Talk to a senior engineer who has worked with companies in your industry. No SDR script, no slide deck. Just a working session about your stack and your compliance posture.</div>
       </div>
       <div style="display:flex;gap:10px;flex-wrap:wrap;">
-        <button class="industry-edtech-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="industry-edtech-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="industry-edtech-btn-secondary-lg" data-book-security>Talk to an Engineer</button>
       </div>
     </div>
@@ -742,7 +742,7 @@
     <h2 class="cta-title">The pentest your auditor will accept.<br>The findings your engineers will fix.</h2>
     <p class="cta-body">Continuous AppSec for SaaS, fintech, and regulated industries. Talk to a senior engineer &mdash; no SDR script, no slide deck, just a working session about your stack.</p>
     <div class="cta-btns">
-      <button class="btn-cta-primary" data-book-security>Book a Pentest</button>
+      <button class="btn-cta-primary" data-contact-form>Book a Pentest</button>
       <button class="btn-cta-ghost" data-book-security>Talk to an Engineer</button>
     </div>
     <div class="cta-trust">

--- a/industry-govtech.html
+++ b/industry-govtech.html
@@ -213,7 +213,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -367,7 +367,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -447,7 +447,7 @@
       <h2 class="industry-govtech-page-title">Pentest evidence for <em>government workloads</em>.</h2>
       <p class="industry-govtech-page-lede">CredShields delivers penetration testing for state and local government platforms, federal-adjacent vendors, public-sector SaaS, and GovTech startups. NIST SP 800-53 alignment, FedRAMP-aware engagement structure, state-level requirements (StateRAMP, TX-RAMP, AZ-RAMP), and the CJIS / IRS Pub 1075 / HIPAA overlays that government workloads inherit.</p>
       <div class="industry-govtech-page-cta-row">
-        <button class="industry-govtech-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="industry-govtech-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="industry-govtech-btn-secondary-lg">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Get Sample Report
@@ -724,7 +724,7 @@
         <div class="industry-govtech-mini-cta-sub">Talk to a senior engineer who has worked with companies in your industry. No SDR script, no slide deck. Just a working session about your stack and your compliance posture.</div>
       </div>
       <div style="display:flex;gap:10px;flex-wrap:wrap;">
-        <button class="industry-govtech-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="industry-govtech-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="industry-govtech-btn-secondary-lg" data-book-security>Talk to an Engineer</button>
       </div>
     </div>
@@ -742,7 +742,7 @@
     <h2 class="cta-title">The pentest your auditor will accept.<br>The findings your engineers will fix.</h2>
     <p class="cta-body">Continuous AppSec for SaaS, fintech, and regulated industries. Talk to a senior engineer &mdash; no SDR script, no slide deck, just a working session about your stack.</p>
     <div class="cta-btns">
-      <button class="btn-cta-primary" data-book-security>Book a Pentest</button>
+      <button class="btn-cta-primary" data-contact-form>Book a Pentest</button>
       <button class="btn-cta-ghost" data-book-security>Talk to an Engineer</button>
     </div>
     <div class="cta-trust">

--- a/js/main.v1.js
+++ b/js/main.v1.js
@@ -9,7 +9,7 @@
 (function () {
   'use strict';
 
-  var bookingUrl = 'https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y';
+  var bookingUrl = 'https://calendly.com/koda-credshields/30min';
   var aiScanFormUrl = 'https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y';
   var chainQuickscanUrl = 'https://solidityscan.com/quickscan';
 
@@ -20,14 +20,22 @@
     }
   }
 
-  function openBookingPopup() {
-    openHubspotPopup(bookingUrl);
+  function openCalendlyPopup(url) {
+    if (window.Calendly && typeof window.Calendly.initPopupWidget === 'function') {
+      window.Calendly.initPopupWidget({ url: url });
+      return;
+    }
+    window.location.href = url;
   }
 
-  function isChainScanCta(cta) {
-    if (cta.classList.contains('show-chain') || cta.closest('.show-chain')) return true;
-    if (cta.classList.contains('show-apps') || cta.closest('.show-apps')) return false;
-    return html.getAttribute('data-mode') === 'chain';
+  function openBookingPopup() {
+    openCalendlyPopup(bookingUrl);
+  }
+
+  function hasNativeLinkTarget(cta) {
+    if (!cta || cta.tagName !== 'A') return false;
+    var href = cta.getAttribute('href') || '';
+    return href && href !== '#';
   }
 
   document.addEventListener('click', function (e) {
@@ -40,12 +48,16 @@
   document.addEventListener('click', function (e) {
     var cta = e.target.closest('[data-free-ai-scan]');
     if (!cta) return;
+    if (hasNativeLinkTarget(cta)) return;
     e.preventDefault();
-    if (isChainScanCta(cta)) {
-      window.location.href = chainQuickscanUrl;
-    } else {
-      openHubspotPopup(aiScanFormUrl);
-    }
+    window.location.href = chainQuickscanUrl;
+  });
+
+  document.addEventListener('click', function (e) {
+    var cta = e.target.closest('[data-contact-form]');
+    if (!cta) return;
+    e.preventDefault();
+    openHubspotPopup(aiScanFormUrl);
   });
 
   /* ── 1. MODE TOGGLE ─────────────────────────────────────── */

--- a/mobile-app-security.html
+++ b/mobile-app-security.html
@@ -206,7 +206,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -360,7 +360,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -396,7 +396,7 @@
       <h1 class="hero-headline">Secure apps in every user's <em>pocket</em>.</h1>
       <p class="hero-body">Mobile apps are gateways for millions of users. CredShields secures iOS and Android apps against reverse engineering, API exploits, and data leakage.</p>
       <div class="hero-ctas">
-        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Mobile App Audit <span>→</span></a>
+        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Mobile App Audit <span>→</span></a>
       </div>
     </div>
     <div class="hero-aside">
@@ -415,7 +415,7 @@
           <span class="dossier-kv-label">Retests</span>
           <span class="dossier-kv-value ok">Free · 90 days</span>
         </div>
-        <div class="dossier-card-foot"><span>Next available: <strong>This week</strong></span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Claim slot →</a></div>
+        <div class="dossier-card-foot"><span>Next available: <strong>This week</strong></span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Claim slot →</a></div>
       </div>
     </div>
   </div>
@@ -646,11 +646,11 @@
     </div>
     <div class="cta-btns">
       <!-- APPS buttons -->
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start a Pentest →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Talk to an Expert ↗</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start a Pentest →</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Talk to an Expert ↗</a>
       <!-- CHAIN buttons -->
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Review ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
+      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Review ↗</a>
     </div>
     <!-- Shared trust strip -->
     <div class="cta-trust">

--- a/mobile-pentest.html
+++ b/mobile-pentest.html
@@ -202,7 +202,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -356,7 +356,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -464,7 +464,7 @@
       <h2 class="mobile-pentest-page-title">iOS and Android, <em>tested like an attacker</em>.</h2>
       <p class="mobile-pentest-page-lede">OWASP MASVS-aligned mobile pentests covering static analysis, dynamic instrumentation, runtime tampering, and certificate pinning bypass. iOS, Android, React Native, Flutter — same depth across all.</p>
       <div class="mobile-pentest-page-cta-row">
-        <button class="mobile-pentest-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="mobile-pentest-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="mobile-pentest-btn-secondary-lg">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Get Sample Report
@@ -792,7 +792,7 @@ $ verify behavior with detection bypassed</pre>
         <div class="mobile-pentest-mini-cta-sub">Talk to a senior engineer. No SDR script, no slide deck — just a working session about your stack.</div>
       </div>
       <div style="display:flex;gap:10px;flex-wrap:wrap;">
-        <button class="mobile-pentest-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="mobile-pentest-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="mobile-pentest-btn-secondary-lg" data-book-security>Talk to an Engineer</button>
       </div>
     </div>
@@ -944,7 +944,7 @@ $ verify behavior with detection bypassed</pre>
     <h2 class="mobile-pentest-cta-title">The pentest your auditor will accept.<br>The findings your engineers will fix.</h2>
     <p class="mobile-pentest-cta-body">Continuous AppSec for SaaS, fintech, and regulated industries. Talk to a senior engineer &mdash; no SDR script, no slide deck, just a working session about your stack.</p>
     <div class="mobile-pentest-cta-btns">
-      <button class="mobile-pentest-btn-cta-primary" data-book-security>Book a Pentest</button>
+      <button class="mobile-pentest-btn-cta-primary" data-contact-form>Book a Pentest</button>
       <button class="mobile-pentest-btn-cta-ghost" data-book-security>Talk to an Engineer</button>
     </div>
     <div class="mobile-pentest-cta-trust">

--- a/owasp-smart-contract-top-10-2025.html
+++ b/owasp-smart-contract-top-10-2025.html
@@ -195,7 +195,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -349,7 +349,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -791,9 +791,9 @@
       <p class="cta-body">Get your comprehensive security audit from the team trusted by 200+ protocols and enterprises worldwide. Fast turnaround. Proven track record. Direct access to senior security engineers.</p>
     </div>
     <div class="cta-btns">
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>Run Free AI Scan ↗</a>
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
+      <a class="btn-cta-ghost show-apps" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
       <a class="btn-cta-ghost show-chain" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan ↗</a>
     </div>
     <div class="cta-trust">

--- a/owasp-smart-contract-top-10-2026.html
+++ b/owasp-smart-contract-top-10-2026.html
@@ -195,7 +195,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -349,7 +349,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -779,9 +779,9 @@
       <p class="cta-body">Get your comprehensive security audit from the team trusted by 200+ protocols and enterprises worldwide. Fast turnaround. Proven track record. Direct access to senior security engineers.</p>
     </div>
     <div class="cta-btns">
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>Run Free AI Scan ↗</a>
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
+      <a class="btn-cta-ghost show-apps" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
       <a class="btn-cta-ghost show-chain" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan ↗</a>
     </div>
     <div class="cta-trust">

--- a/payments.html
+++ b/payments.html
@@ -205,7 +205,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -359,7 +359,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -395,7 +395,7 @@
       <h1 class="hero-headline">Replacing SWIFT with smart contracts requires <em>sovereign</em> security.</h1>
       <p class="hero-body">Banks and payment institutions building on-chain cross-border settlement rails are replacing correspondent banking infrastructure that moves trillions of dollars annually. Smart contracts that execute FX, clear payments, and enforce compliance across jurisdictions must be flawless. A single vulnerability does not affect one transaction — it affects every payment that flows through the protocol.</p>
       <div class="hero-ctas">
-        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Infrastructure Briefing <span>→</span></a>
+        <a class="btn-primary-lg" href="https://calendly.com/koda-credshields/30min" data-book-security>Infrastructure Briefing <span>→</span></a>
         <a class="btn-secondary-lg" href="#critical-risk-vectors">View Attack Surface <span>↗</span></a>
       </div>
     </div>
@@ -415,7 +415,7 @@
           <span class="dossier-kv-label">Reversibility</span>
           <span class="dossier-kv-value">None · contractually final</span>
         </div>
-        <div class="dossier-card-foot"><span>Next briefing slot: <strong>This week</strong></span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book briefing →</a></div>
+        <div class="dossier-card-foot"><span>Next briefing slot: <strong>This week</strong></span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Book briefing →</a></div>
       </div>
     </div>
   </div>
@@ -741,9 +741,9 @@
       <p class="cta-body">Request a private infrastructure briefing. We will scope the right security program for your payment architecture, currency corridors, regulatory jurisdiction, and go-live timeline. NDA available as standard.</p>
     </div>
     <div class="cta-btns">
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start a Pentest →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Talk to an Expert ↗</a>
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Security Briefing →</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start a Pentest →</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Talk to an Expert ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://calendly.com/koda-credshields/30min" data-book-security>Request Security Briefing →</a>
       <button class="btn-cta-ghost show-chain" data-free-ai-scan>
         <span>Run Free</span>
         <img src="images/ai_icon_magic.svg" alt="AI scan" />

--- a/penetration-testing.html
+++ b/penetration-testing.html
@@ -208,7 +208,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -362,7 +362,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -398,7 +398,7 @@
       <h1 class="hero-headline">Test like hackers.<br>Fix before <em>they do</em>.</h1>
       <p class="hero-body">CredShields' AI-led penetration testing simulates real-world attack scenarios on web apps, mobile apps, APIs, networks, and cloud environments to reveal vulnerabilities before attackers exploit them. AI-augmented engineers combine machine intelligence with human expertise for deeper, faster, more accurate results.</p>
       <div class="hero-ctas">
-        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Get a Pentest Quote <span>→</span></a>
+        <a class="btn-primary-lg" href="https://calendly.com/koda-credshields/30min" data-book-security>Get a Pentest Quote <span>→</span></a>
         <a class="btn-secondary-lg" href="#case-study">Read a Case Study <span>↗</span></a>
       </div>
     </div>
@@ -418,7 +418,7 @@
           <span class="dossier-kv-label">Reports</span>
           <span class="dossier-kv-value ok">Executive + Technical</span>
         </div>
-        <div class="dossier-card-foot"><span>Next available: <strong>Mon 28 Apr</strong></span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Claim slot →</a></div>
+        <div class="dossier-card-foot"><span>Next available: <strong>Mon 28 Apr</strong></span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Claim slot →</a></div>
       </div>
     </div>
   </div>
@@ -698,11 +698,11 @@
     </div>
     <div class="cta-btns">
       <!-- APPS buttons -->
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start a Pentest →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Talk to an Expert ↗</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start a Pentest →</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Talk to an Expert ↗</a>
       <!-- CHAIN buttons -->
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Review ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
+      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Review ↗</a>
     </div>
     <!-- Shared trust strip -->
     <div class="cta-trust">

--- a/pentest-vs-scan.html
+++ b/pentest-vs-scan.html
@@ -213,7 +213,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -367,7 +367,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -655,7 +655,7 @@
         <div class="pentest-vs-scan-mini-cta-sub">Talk to a senior engineer. No SDR script, no slide deck. Just a working session about your stack.</div>
       </div>
       <div style="display:flex;gap:10px;flex-wrap:wrap;">
-        <button class="pentest-vs-scan-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="pentest-vs-scan-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="pentest-vs-scan-btn-secondary-lg" data-book-security>Talk to an Engineer</button>
       </div>
     </div>
@@ -673,7 +673,7 @@
     <h2 class="cta-title">The pentest your auditor will accept.<br>The findings your engineers will fix.</h2>
     <p class="cta-body">Continuous AppSec for SaaS, fintech, and regulated industries. Talk to a senior engineer &mdash; no SDR script, no slide deck, just a working session about your stack.</p>
     <div class="cta-btns">
-      <button class="btn-cta-primary" data-book-security>Book a Pentest</button>
+      <button class="btn-cta-primary" data-contact-form>Book a Pentest</button>
       <button class="btn-cta-ghost" data-book-security>Talk to an Engineer</button>
     </div>
     <div class="cta-trust">

--- a/realworldassets.html
+++ b/realworldassets.html
@@ -207,7 +207,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -361,7 +361,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -396,7 +396,7 @@
       <h1 class="hero-headline">$16 Trillion in Traditional Assets Going Onchain. Security Must <em>Match</em>.</h1>
       <p class="hero-body">Bonds, real estate, credit instruments, and private equity being tokenized onto blockchain infrastructure carry the full weight of their underlying value in contracts that are immutable, public, and irreversible. The security standard must match. RWA tokenization programs now account for the fastest-growing attack surface in institutional Web3.</p>
       <div class="hero-ctas">
-        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Security Briefing <span>→</span></a>
+        <a class="btn-primary-lg" href="https://calendly.com/koda-credshields/30min" data-book-security>Request Security Briefing <span>→</span></a>
         <a class="btn-secondary-lg" href="#attack_surface">View Risk Surface <span>↗</span></a>
       </div>
     </div>
@@ -416,7 +416,7 @@
           <span class="dossier-kv-label">Outcome</span>
           <span class="dossier-kv-value ok">Audit-ready</span>
         </div>
-        <div class="dossier-card-foot"><span>Briefing window: <strong>This week</strong></span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book briefing →</a></div>
+        <div class="dossier-card-foot"><span>Briefing window: <strong>This week</strong></span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Book briefing →</a></div>
       </div>
     </div>
   </div>
@@ -558,9 +558,9 @@
       <p class="cta-body">Request a briefing scoped to your RWA product type, underlying asset class, and regulatory jurisdiction.</p>
     </div>
     <div class="cta-btns">
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start a Pentest →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Talk to an Expert ↗</a>
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Security Briefing →</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start a Pentest →</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Talk to an Expert ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://calendly.com/koda-credshields/30min" data-book-security>Request Security Briefing →</a>
       <a class="btn-cta-ghost show-chain" href="https://solidityscan.com/quickscan" data-free-ai-scan>
         <span style="color:#ffffff;font-weight:700;margin-right:1px">Run Free</span>
         <img src="images/ai_icon_magic.svg" alt="ai_icon_magic" style="width:16px;height:16px;vertical-align:middle;" />

--- a/recently-audited.html
+++ b/recently-audited.html
@@ -205,7 +205,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -359,7 +359,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>

--- a/red-team.html
+++ b/red-team.html
@@ -202,7 +202,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -356,7 +356,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -472,7 +472,7 @@
       <h2 class="red-team-page-title">Goal-oriented <em>adversarial simulation</em>.</h2>
       <p class="red-team-page-lede">Multi-week engagements where we work toward specific objectives — not a finding count. Phishing, endpoint compromise, lateral movement, exfiltration. Mapped to MITRE ATT&CK with detection metrics included.</p>
       <div class="red-team-page-cta-row">
-        <button class="red-team-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="red-team-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="red-team-btn-secondary-lg">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Get Sample Report
@@ -812,7 +812,7 @@
         <div class="red-team-mini-cta-sub">Talk to a senior engineer. No SDR script, no slide deck — just a working session about your stack.</div>
       </div>
       <div style="display:flex;gap:10px;flex-wrap:wrap;">
-        <button class="red-team-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="red-team-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="red-team-btn-secondary-lg" data-book-security>Talk to an Engineer</button>
       </div>
     </div>
@@ -918,7 +918,7 @@
     <h2 class="red-team-cta-title">The pentest your auditor will accept.<br>The findings your engineers will fix.</h2>
     <p class="red-team-cta-body">Continuous AppSec for SaaS, fintech, and regulated industries. Talk to a senior engineer &mdash; no SDR script, no slide deck, just a working session about your stack.</p>
     <div class="red-team-cta-btns">
-      <button class="red-team-btn-cta-primary" data-book-security>Book a Pentest</button>
+      <button class="red-team-btn-cta-primary" data-contact-form>Book a Pentest</button>
       <button class="red-team-btn-cta-ghost" data-book-security>Talk to an Engineer</button>
     </div>
     <div class="red-team-cta-trust">

--- a/saas-security.html
+++ b/saas-security.html
@@ -207,7 +207,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -361,7 +361,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -397,8 +397,8 @@
       <h1 class="hero-headline">Enterprise-grade protection for cloud &amp; <em>SaaS</em>.</h1>
       <p class="hero-body">Modern SaaS and digital-first enterprises operate in multi-cloud environments, with complex infrastructures and millions of users. CredShields provides penetration testing, cloud security reviews, and compliance-focused audits.</p>
       <div class="hero-ctas">
-        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Audit <span>→</span></a>
-        <a class="btn-secondary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
+        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Audit <span>→</span></a>
+        <a class="btn-secondary-lg" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
       </div>
     </div>
     <div class="hero-aside">
@@ -417,7 +417,7 @@
           <span class="dossier-kv-label">Retests</span>
           <span class="dossier-kv-value ok">Free · 90 days</span>
         </div>
-        <div class="dossier-card-foot"><span>Enterprise-ready reports</span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Claim slot →</a></div>
+        <div class="dossier-card-foot"><span>Enterprise-ready reports</span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Claim slot →</a></div>
       </div>
     </div>
   </div>
@@ -625,11 +625,11 @@
     </div>
     <div class="cta-btns">
       <!-- APPS buttons -->
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start Enterprise Audit</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Schedule Consultation</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start Enterprise Audit</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Schedule Consultation</a>
       <!-- CHAIN buttons -->
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Review ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
+      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Review ↗</a>
     </div>
     <!-- Shared trust strip -->
     <div class="cta-trust">

--- a/sample-report.html
+++ b/sample-report.html
@@ -213,7 +213,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -367,7 +367,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -663,7 +663,7 @@
         <div class="sample-report-mini-cta-sub">Talk to a senior engineer. No SDR script, no slide deck. Just a working session about your stack.</div>
       </div>
       <div style="display:flex;gap:10px;flex-wrap:wrap;">
-        <button class="sample-report-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="sample-report-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="sample-report-btn-secondary-lg" data-book-security>Talk to an Engineer</button>
       </div>
     </div>
@@ -681,7 +681,7 @@
     <h2 class="cta-title">The pentest your auditor will accept.<br>The findings your engineers will fix.</h2>
     <p class="cta-body">Continuous AppSec for SaaS, fintech, and regulated industries. Talk to a senior engineer &mdash; no SDR script, no slide deck, just a working session about your stack.</p>
     <div class="cta-btns">
-      <button class="btn-cta-primary" data-book-security>Book a Pentest</button>
+      <button class="btn-cta-primary" data-contact-form>Book a Pentest</button>
       <button class="btn-cta-ghost" data-book-security>Talk to an Engineer</button>
     </div>
     <div class="cta-trust">

--- a/sast.html
+++ b/sast.html
@@ -213,7 +213,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -367,7 +367,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -439,7 +439,7 @@
       <h2 class="sast-page-title">SAST that <em>doesn't flood your backlog</em>.</h2>
       <p class="sast-page-lede">Source code review and static application security testing (SAST), engineer-curated to suppress false positives. Continuous coverage between manual pentests, integrated with your CI and your existing tool stack. Complement to pentesting, not a replacement.</p>
       <div class="sast-page-cta-row">
-        <button class="sast-btn-primary-lg">Book SAST Engagement</button>
+        <button class="sast-btn-primary-lg" data-contact-form>Book SAST Engagement</button>
         <button class="sast-btn-secondary-lg">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Get Sample Report
@@ -688,7 +688,7 @@
         <div class="sast-mini-cta-sub">Talk to a senior engineer. No SDR script, no slide deck. Just a working session about your stack.</div>
       </div>
       <div style="display:flex;gap:10px;flex-wrap:wrap;">
-        <button class="sast-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="sast-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="sast-btn-secondary-lg" data-book-security>Talk to an Engineer</button>
       </div>
     </div>
@@ -706,7 +706,7 @@
     <h2 class="cta-title">The pentest your auditor will accept.<br>The findings your engineers will fix.</h2>
     <p class="cta-body">Continuous AppSec for SaaS, fintech, and regulated industries. Talk to a senior engineer &mdash; no SDR script, no slide deck, just a working session about your stack.</p>
     <div class="cta-btns">
-      <button class="btn-cta-primary" data-book-security>Book a Pentest</button>
+      <button class="btn-cta-primary" data-contact-form>Book a Pentest</button>
       <button class="btn-cta-ghost" data-book-security>Talk to an Engineer</button>
     </div>
     <div class="cta-trust">

--- a/security-consulting.html
+++ b/security-consulting.html
@@ -207,7 +207,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -361,7 +361,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -397,7 +397,7 @@
       <p class="hero-body">Security is not a tool, it is a strategy. Whether you are building a decentralized protocol, scaling enterprise applications, or expanding into regulated markets, your security posture determines your long-term resilience.</p>
       <div class="hero-ctas">
         <a class="btn-primary-lg" href="index.html#security_coverage_360">Explore Our Solutions <span>→</span></a>
-        <a class="btn-secondary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
+        <a class="btn-secondary-lg" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
       </div>
     </div>
     <div class="hero-aside">
@@ -416,7 +416,7 @@
           <span class="dossier-kv-label">Outcome</span>
           <span class="dossier-kv-value ok">Audit-ready posture</span>
         </div>
-        <div class="dossier-card-foot"><span>Next available: <strong>This week</strong></span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Claim slot →</a></div>
+        <div class="dossier-card-foot"><span>Next available: <strong>This week</strong></span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Claim slot →</a></div>
       </div>
     </div>
   </div>
@@ -575,15 +575,15 @@
     </div>
     <div class="cta-btns">
       <!-- APPS buttons -->
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Consultation →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" style="display:inline-flex;align-items:center;gap:5px;" data-free-ai-scan>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Consultation →</a>
+      <a class="btn-cta-ghost show-apps" href="https://solidityscan.com/quickscan" style="display:inline-flex;align-items:center;gap:5px;" data-free-ai-scan>
         <span>Run Free</span>
         <img src="images/ai_icon_magic.svg" alt="ai_icon_magic" style="width:15px;height:15px;" />
         <span style="color:#A8FF45;">AI Scan</span>
       </a>
       <!-- CHAIN buttons -->
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Review ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
+      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Review ↗</a>
     </div>
     <!-- Trust strip -->
     <div class="cta-trust">

--- a/security-training.html
+++ b/security-training.html
@@ -207,7 +207,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -361,7 +361,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -397,7 +397,7 @@
       <p class="hero-body">Modern engineering teams operate in complex environments: smart contracts, cloud systems, APIs, DevOps pipelines, mobile apps, and cross-chain integrations. Without deep security awareness, even the best developers can unintentionally introduce critical vulnerabilities.</p>
       <div class="hero-ctas">
         <a class="btn-primary-lg" href="index.html#security_coverage_360">Explore Our Solutions <span>→</span></a>
-        <a class="btn-secondary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
+        <a class="btn-secondary-lg" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
       </div>
     </div>
     <div class="hero-aside">
@@ -562,15 +562,15 @@
     </div>
     <div class="cta-btns">
       <!-- APPS buttons -->
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Consultation</a>
-      <a class="btn-cta-ghost show-apps" style="cursor:pointer;display:inline-flex;align-items:center;gap:6px;" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Consultation</a>
+      <a class="btn-cta-ghost show-apps" style="cursor:pointer;display:inline-flex;align-items:center;gap:6px;" href="https://solidityscan.com/quickscan" data-free-ai-scan>
         <span style="color: #ffffff; font-weight: 700; margin-right: 1px">Run Free</span>
         <img src="images/ai_icon_magic.svg" alt="ai_icon_magic" style="width:18px;height:18px;object-fit:contain;" />
         <span style="color: #38ff7e; font-weight: 700; margin-left: 1px">AI Scan</span>
       </a>
       <!-- CHAIN buttons -->
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Manual Audit →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Book Security Review ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Manual Audit →</a>
+      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Book Security Review ↗</a>
     </div>
     <!-- Shared trust strip -->
     <div class="cta-trust">

--- a/smart-contract-audits.html
+++ b/smart-contract-audits.html
@@ -205,7 +205,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -359,7 +359,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -415,7 +415,7 @@
           <span class="dossier-kv-label">FPs</span>
           <span class="dossier-kv-value ok">Contractually zero</span>
         </div>
-        <div class="dossier-card-foot"><span>Next available: <strong>Mon 04 May</strong></span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Claim slot →</a></div>
+        <div class="dossier-card-foot"><span>Next available: <strong>Mon 04 May</strong></span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Claim slot →</a></div>
       </div>
     </div>
   </div>
@@ -666,10 +666,10 @@
     </div>
     <div class="cta-btns">
       <!-- APPS buttons (verbatim) -->
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start a Pentest →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Talk to an Expert ↗</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start a Pentest →</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Talk to an Expert ↗</a>
       <!-- CHAIN buttons (source) -->
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Consultation →</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Consultation →</a>
       <a class="btn-cta-ghost show-chain" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan ↗</a>
     </div>
     <!-- Trust strip -->

--- a/stablecoins.html
+++ b/stablecoins.html
@@ -207,7 +207,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -361,7 +361,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -397,7 +397,7 @@
       <h1 class="hero-headline">Billions in pegged value.<br>One contract flaw breaks the <em>peg</em>.</h1>
       <p class="hero-body">Fiat-backed, algorithmic, and collateralized stablecoins are the most targeted smart contracts in DeFi. CredShields provides the independent security assurance regulators and exchanges demand before any stablecoin goes live.</p>
       <div class="hero-ctas">
-        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Security Briefing <span>→</span></a>
+        <a class="btn-primary-lg" href="https://calendly.com/koda-credshields/30min" data-book-security>Request Security Briefing <span>→</span></a>
         <a class="btn-secondary-lg" href="#attack_surface">View Risk Surface <span>↗</span></a>
       </div>
     </div>
@@ -417,7 +417,7 @@
           <span class="dossier-kv-label">Retainer</span>
           <span class="dossier-kv-value ok">Post-launch monitoring</span>
         </div>
-        <div class="dossier-card-foot"><span>Briefing: <strong>30 min</strong></span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Claim slot →</a></div>
+        <div class="dossier-card-foot"><span>Briefing: <strong>30 min</strong></span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Claim slot →</a></div>
       </div>
     </div>
   </div>
@@ -562,9 +562,9 @@
       <p class="cta-body">Request a private briefing. We will scope the right audit program for your stablecoin architecture, peg mechanism, and regulatory jurisdiction.</p>
     </div>
     <div class="cta-btns">
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start a Pentest →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Talk to an Expert ↗</a>
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Security Briefing →</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start a Pentest →</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Talk to an Expert ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://calendly.com/koda-credshields/30min" data-book-security>Request Security Briefing →</a>
       <a class="btn-cta-ghost show-chain" href="https://solidityscan.com/quickscan" data-free-ai-scan>
         <span style="color:#ffffff;font-weight:700;margin-right:1px">Run Free</span>
         <img src="images/ai_icon_magic.svg" alt="ai_icon_magic" style="width:16px;height:16px;vertical-align:middle;" />

--- a/vc-crypto-funds.html
+++ b/vc-crypto-funds.html
@@ -206,7 +206,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -360,7 +360,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -395,7 +395,7 @@
       <h1 class="hero-headline">Secure your entire <em>portfolio</em>.</h1>
       <p class="hero-body">Every protocol your fund backs will need a security audit before launch, before listing, and before the next raise. CredShields is the institutional standard — one relationship that scales across your entire deal flow.</p>
       <div class="hero-ctas">
-        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Fund Briefing <span>→</span></a>
+        <a class="btn-primary-lg" href="https://calendly.com/koda-credshields/30min" data-book-security>Request Fund Briefing <span>→</span></a>
         <a class="btn-secondary-lg" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
       </div>
     </div>
@@ -417,7 +417,7 @@
           <span class="dossier-kv-label">Outcome</span>
           <span class="dossier-kv-value ok">Listing-ready protocols</span>
         </div>
-        <div class="dossier-card-foot"><span>Next briefing: <strong>This week</strong></span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Reserve a slot →</a></div>
+        <div class="dossier-card-foot"><span>Next briefing: <strong>This week</strong></span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Reserve a slot →</a></div>
       </div>
     </div>
   </div>
@@ -596,9 +596,9 @@
       <p class="cta-body">Don't let security vulnerabilities threaten your protocol and users. Get a comprehensive audit from the team trusted by the world's leading DeFi protocols.</p>
     </div>
     <div class="cta-btns">
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Consultation →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-free-ai-scan>Run Free AI Scan ↗</a>
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Consultation →</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Consultation →</a>
+      <a class="btn-cta-ghost show-apps" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Consultation →</a>
       <a class="btn-cta-ghost show-chain" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan ↗</a>
     </div>
     <div class="cta-trust">

--- a/wallet-security.html
+++ b/wallet-security.html
@@ -204,7 +204,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -358,7 +358,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -394,7 +394,7 @@
       <h1 class="hero-headline">Protect the keys to your <em>kingdom</em>.</h1>
       <p class="hero-body">Wallets are prime targets, from phishing to key theft. CredShields provides wallet security audits and penetration testing to safeguard funds.</p>
       <div class="hero-ctas">
-        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Wallet Security Audit <span>→</span></a>
+        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Wallet Security Audit <span>→</span></a>
       </div>
     </div>
     <div class="hero-aside">
@@ -413,7 +413,7 @@
           <span class="dossier-kv-label">Outcome</span>
           <span class="dossier-kv-value ok">Funds protected</span>
         </div>
-        <div class="dossier-card-foot"><span>Engagement: <strong>Wallet audit</strong></span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start audit →</a></div>
+        <div class="dossier-card-foot"><span>Engagement: <strong>Wallet audit</strong></span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start audit →</a></div>
       </div>
     </div>
   </div>
@@ -644,10 +644,10 @@
       <p class="cta-body">Don't let wallet vulnerabilities expose your users and treasury to theft. Get a comprehensive wallet security audit from the experts.</p>
     </div>
     <div class="cta-btns">
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start a Pentest →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Talk to an Expert ↗</a>
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Wallet Security Audit →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Schedule Consultation ↗</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start a Pentest →</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Talk to an Expert ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Wallet Security Audit →</a>
+      <a class="btn-cta-ghost show-chain" href="https://calendly.com/koda-credshields/30min" data-book-security>Schedule Consultation ↗</a>
     </div>
     <div class="cta-trust">
       <div>

--- a/web-app-security.html
+++ b/web-app-security.html
@@ -206,7 +206,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -360,7 +360,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -396,7 +396,7 @@
       <h1 class="hero-headline">Your web app is the frontline.<br><em>Secure</em> it.</h1>
       <p class="hero-body">Web apps are the most common entry point for attackers. CredShields delivers application security testing aligned with OWASP Top 10 to stop attacks before they escalate.</p>
       <div class="hero-ctas">
-        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Request Web App Audit <span>→</span></a>
+        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Request Web App Audit <span>→</span></a>
         <a class="btn-secondary-lg" href="#process">See the process <span>↗</span></a>
       </div>
     </div>
@@ -416,7 +416,7 @@
           <span class="dossier-kv-label">Retests</span>
           <span class="dossier-kv-value ok">Free · 90 days</span>
         </div>
-        <div class="dossier-card-foot"><span>Next available: <strong>Mon 28 Apr</strong></span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Claim slot →</a></div>
+        <div class="dossier-card-foot"><span>Next available: <strong>Mon 28 Apr</strong></span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Claim slot →</a></div>
       </div>
     </div>
   </div>

--- a/web-pentest.html
+++ b/web-pentest.html
@@ -202,7 +202,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -356,7 +356,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -464,7 +464,7 @@
       <h2 class="web-pentest-page-title">Find what your <em>scanner can't</em>.</h2>
       <p class="web-pentest-page-lede">Manual web app pentesting against OWASP ASVS L2/L3. Business logic flaws, multi-tenant isolation, complex auth flows — the bugs scanners miss and consultants charge $80k for.</p>
       <div class="web-pentest-page-cta-row">
-        <button class="web-pentest-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="web-pentest-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="web-pentest-btn-secondary-lg">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Get Sample Report
@@ -806,7 +806,7 @@
         <div class="web-pentest-mini-cta-sub">Talk to a senior engineer. No SDR script, no slide deck — just a working session about your stack.</div>
       </div>
       <div style="display:flex;gap:10px;flex-wrap:wrap;">
-        <button class="web-pentest-btn-primary-lg" data-book-security>Book a Pentest</button>
+        <button class="web-pentest-btn-primary-lg" data-contact-form>Book a Pentest</button>
         <button class="web-pentest-btn-secondary-lg" data-book-security>Talk to an Engineer</button>
       </div>
     </div>
@@ -979,7 +979,7 @@
     <h2 class="web-pentest-cta-title">The pentest your auditor will accept.<br>The findings your engineers will fix.</h2>
     <p class="web-pentest-cta-body">Continuous AppSec for SaaS, fintech, and regulated industries. Talk to a senior engineer &mdash; no SDR script, no slide deck, just a working session about your stack.</p>
     <div class="web-pentest-cta-btns">
-      <button class="web-pentest-btn-cta-primary" data-book-security>Book a Pentest</button>
+      <button class="web-pentest-btn-cta-primary" data-contact-form>Book a Pentest</button>
       <button class="web-pentest-btn-cta-ghost" data-book-security>Talk to an Engineer</button>
     </div>
     <div class="web-pentest-cta-trust">

--- a/web3-protocol-security.html
+++ b/web3-protocol-security.html
@@ -207,7 +207,7 @@
         <button class="mode-toggle-btn" data-mode="apps" role="tab" aria-pressed="true">Apps</button>
         <button class="mode-toggle-btn" data-mode="chain" role="tab" aria-pressed="false">Chain</button>
       </div>
-      <button class="btn-primary" data-book-security>Book Security Audit</button>
+      <button class="btn-primary" data-contact-form>Book Security Audit</button>
     </div>
 
     <!-- Mobile Menu Button -->
@@ -361,7 +361,7 @@
   </div>
 
   <div class="mobile-overlay-cta">
-    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-book-security>Book Security Audit</button>
+    <button class="btn-primary-lg" style="width:100%;text-align:center;" data-contact-form>Book Security Audit</button>
     <button class="btn-secondary-lg" style="width:100%;justify-content:center;" data-free-ai-scan>Run Free AI Scan</button>
   </div>
 </div>
@@ -397,7 +397,7 @@
       <h1 class="hero-headline">Institutional-grade security for <em>Web3 protocols</em>.</h1>
       <p class="hero-body">Billions in on-chain value are lost every year to hacks, with smart contract flaws and exchange vulnerabilities being top drivers. CredShields secures DeFi protocols, dApps, and centralized exchanges.</p>
       <div class="hero-ctas">
-        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Smart Contract Audit <span>→</span></a>
+        <a class="btn-primary-lg" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Smart Contract Audit <span>→</span></a>
         <a class="btn-secondary-lg" href="https://solidityscan.com/quickscan" data-free-ai-scan>Run Free AI Scan <span>↗</span></a>
       </div>
     </div>
@@ -417,7 +417,7 @@
           <span class="dossier-kv-label">Reports</span>
           <span class="dossier-kv-value ok">Investor-ready</span>
         </div>
-        <div class="dossier-card-foot"><span>Next available: <strong>This week</strong></span><a class="dossier-card-cta" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Claim slot →</a></div>
+        <div class="dossier-card-foot"><span>Next available: <strong>This week</strong></span><a class="dossier-card-cta" href="https://calendly.com/koda-credshields/30min" data-book-security>Claim slot →</a></div>
       </div>
     </div>
   </div>
@@ -607,10 +607,10 @@
       <p class="cta-body">Protect your protocol, users, and reputation. Get institutional-grade security before your next deployment.</p>
     </div>
     <div class="cta-btns">
-      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Start a Pentest →</a>
-      <a class="btn-cta-ghost show-apps" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Talk to an Expert ↗</a>
-      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Smart Contract Audit →</a>
-      <a class="btn-cta-ghost show-chain" href="https://share-eu1.hsforms.com/2sIrgwu_PRrq0Y3dNK4ZSTAeth5y" data-book-security>Schedule Consultation ↗</a>
+      <a class="btn-cta-primary show-apps" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Start a Pentest →</a>
+      <a class="btn-cta-ghost show-apps" href="https://calendly.com/koda-credshields/30min" data-book-security>Talk to an Expert ↗</a>
+      <a class="btn-cta-primary show-chain" href="https://share-eu1.hsforms.com/2zCMAi8R0SD6rmwMc_-UwBQeth5y" data-contact-form>Smart Contract Audit →</a>
+      <a class="btn-cta-ghost show-chain" href="https://calendly.com/koda-credshields/30min" data-book-security>Schedule Consultation ↗</a>
     </div>
     <div class="cta-trust">
       <div>


### PR DESCRIPTION
Resolve crawl QA findings across internal links, metadata, redirects, audit feed data, KYC downloads, copy consistency, and accessibility alt text.

Update CTA routing so scan CTAs point to SolidityScan QuickScan, engineer/contact CTAs open Calendly, and audit/request CTAs use the HubSpot form. Add a grouped CTA inventory report documenting CTA names, source files, and resolved destinations.